### PR TITLE
Fix build error

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/casbin/casbin/model"
 	"github.com/casbin/casbin/persist"
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
+// CasbinRule is used to determine which policy line to load.
 type CasbinRule struct {
 	PType string `xorm:"varchar(100) index"`
 	V0    string `xorm:"varchar(100) index"`


### PR DESCRIPTION
When the `github.com/garyburd/redigo/redis` package was being used, I would receive a error about the use of a internal package when I attempted to build my binary. Changing to `github.com/gomodule/redigo/redis` fixed this issue. The test succeeded with the change.